### PR TITLE
[0.x] Allow the generation to be controlled

### DIFF
--- a/src/StringFormatter.php
+++ b/src/StringFormatter.php
@@ -5,16 +5,87 @@ namespace Cndrsdrmn\PhpStringFormatter;
 class StringFormatter
 {
     /**
+     * The callback that should be used to generate bothify strings.
+     *
+     * @var callable|null
+     */
+    protected static $bothifyFactory;
+
+    /**
+     * The callback that should be used to generate lexify strings.
+     *
+     * @var callable|null
+     */
+    protected static $lexifyFactory;
+
+    /**
+     * The callback that should be used to generate numerify strings.
+     *
+     * @var callable|null
+     */
+    protected static $numerifyFactory;
+
+    /**
      * Replace both `#` with random digits and `?` with random lowercase letters.
      * Replaces `*` with either `#` or `?`.
      */
     public static function bothify(string $string): string
     {
-        // Replace '*' with either '#' or '?'
-        $string = static::replaceWildcard($string, '*', fn (): string => mt_rand(0, 1) === 1 ? '#' : '?');
+        return (static::$bothifyFactory ?? function ($string): string {
+            // Replace '*' with either '#' or '?'
+            $string = static::replaceWildcard($string, '*', fn (): string => mt_rand(0, 1) === 1 ? '#' : '?');
 
-        // Apply numerify and lexify to replace '#' with digits and '?' with letters
-        return static::lexify(static::numerify($string));
+            // Apply numerify and lexify to replace '#' with digits and '?' with letters
+            return static::lexify(static::numerify($string));
+        })($string);
+    }
+
+    /**
+     * Set the callback that will be used to generate bothify strings.
+     */
+    public static function createBothifyUsing(callable $callable): void
+    {
+        static::$bothifyFactory = $callable;
+    }
+
+    /**
+     * Indicate that bothify strings should be created normally and not using a custom factory.
+     */
+    public static function createBothifyNormally(): void
+    {
+        static::$bothifyFactory = null;
+    }
+
+    /**
+     * Set the callback that will be used to generate lexify strings.
+     */
+    public static function createLexifyUsing(callable $callable): void
+    {
+        static::$lexifyFactory = $callable;
+    }
+
+    /**
+     * Indicate that lexify strings should be created normally and not using a custom factory.
+     */
+    public static function createLexifyNormally(): void
+    {
+        static::$lexifyFactory = null;
+    }
+
+    /**
+     * Set the callback that will be used to generate numerify strings.
+     */
+    public static function createNumerifyUsing(callable $callable): void
+    {
+        static::$numerifyFactory = $callable;
+    }
+
+    /**
+     * Indicate that numerify strings should be created normally and not using a custom factory.
+     */
+    public static function createNumerifyNormally(): void
+    {
+        static::$numerifyFactory = null;
     }
 
     /**
@@ -22,7 +93,7 @@ class StringFormatter
      */
     public static function lexify(string $string): string
     {
-        return static::replaceWildcard($string, '?', fn (): string => chr(mt_rand(97, 122)));
+        return (static::$lexifyFactory ?? fn (string $string): string => static::replaceWildcard($string, '?', fn (): string => chr(mt_rand(97, 122))))($string);
     }
 
     /**
@@ -30,11 +101,13 @@ class StringFormatter
      */
     public static function numerify(string $string): string
     {
-        // Replace `#` with random digits
-        $string = static::replaceWildcard($string, '#', fn (): int => mt_rand(0, 9));
+        return (static::$numerifyFactory ?? function (string $string): string {
+            // Replace `#` with random digits
+            $string = static::replaceWildcard($string, '#', fn (): int => mt_rand(0, 9));
 
-        // Replace `%` with random digits between 1 and 9
-        return static::replaceWildcard($string, '%', fn (): int => mt_rand(1, 9));
+            // Replace `%` with random digits between 1 and 9
+            return static::replaceWildcard($string, '%', fn (): int => mt_rand(1, 9));
+        })($string);
     }
 
     /**

--- a/tests/StringFormatterTest.php
+++ b/tests/StringFormatterTest.php
@@ -8,6 +8,18 @@ it('bothify method can replaces `*` with random `#` or `?`, `#` with digits and 
     expect($string)->toMatch('/Foo \d{1}|[a-z]{1}\d{3}[a-z]{1}/');
 });
 
+it('bothify generation to be controlled', function (): void {
+    StringFormatter::createBothifyUsing(fn (): string => 'bothify');
+
+    expect(StringFormatter::bothify('Foo *###?'))->toBe('bothify');
+
+    StringFormatter::createBothifyNormally();
+
+    expect(StringFormatter::bothify('Foo *###?'))
+        ->toMatch('/Foo \d{1}|[a-z]{1}\d{3}[a-z]{1}/')
+        ->not->toBe('bothify');
+});
+
 it('numerify method which replaces `#` with digits and `%` with digits from 1-9', function (): void {
     $stringWithZero = StringFormatter::numerify('Foo ####');
     $stringWithoutZero = StringFormatter::numerify('Foo %%%%');
@@ -18,8 +30,33 @@ it('numerify method which replaces `#` with digits and `%` with digits from 1-9'
         ->toMatch('/Foo [1-9]{4}/');
 });
 
+it('numerify generation to be controlled', function (): void {
+    StringFormatter::createNumerifyUsing(fn (): string => 'number');
+
+    expect(StringFormatter::numerify('Foo ####'))->toBe('number');
+
+    StringFormatter::createNumerifyNormally();
+
+    expect(StringFormatter::numerify('Foo %%%%'))
+        ->toMatch('/Foo \d{4}/')
+        ->toMatch('/Foo [1-9]{4}/')
+        ->not->toBe('number');
+});
+
 it('lexify method can replaces `?` with random lowercase letters', function (): void {
-    $string = StringFormatter::bothify('Foo ????');
+    $string = StringFormatter::lexify('Foo ????');
 
     expect($string)->toMatch('/Foo [a-z]{4}/');
+});
+
+it('lexify generation to be controlled', function (): void {
+    StringFormatter::createLexifyUsing(fn (): string => 'letter');
+
+    expect(StringFormatter::lexify('Foo ????'))->toBe('letter');
+
+    StringFormatter::createLexifyNormally();
+
+    expect(StringFormatter::lexify('Foo ????'))
+        ->toMatch('/Foo [a-z]{4}/')
+        ->not->toBe('letter');
 });


### PR DESCRIPTION
## Added

* `StringFormatter::createBothifyUsing`
* `StringFormatter::createLexifyUsing`
* `StringFormatter::createNumerifyUsing`
* `StringFormatter::createBothifyNormally`
* `StringFormatter::createLexifyNormally`
* `StringFormatter::createNumerifyNormally`

## Updated

* `StringFormatter::bothify`
* `StringFormatter::lexify`
* `StringFormatter::numerify`